### PR TITLE
fix: add missing sed command

### DIFF
--- a/.github/workflows/sign-with-ta.yml
+++ b/.github/workflows/sign-with-ta.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Sign
         run: |
+          sudo apt-get update
+          sudo apt-get install -y sed 
           mkdir -p ./cas/TA/private
           mkdir -p ./cas/TA/certs
           cp ./scripts/signing/openssl.conf ./cas/TA/openssl.conf


### PR DESCRIPTION
 - sed command seems to be missing on ubuntu:latest (per 01/2024)