### PR TITLE
Update groups_domains.py by adding domain PH4H

### DIFF
--- a/scripts/tests/groups_domains.py
+++ b/scripts/tests/groups_domains.py
@@ -10,4 +10,4 @@ def test_valid_domain(cert):
 
     domain = cert.pathinfo.get('domain')
     assert domain, 'Certificate at incorrect location'
-    assert domain.upper() in ('DCC','DDCC','DIVOC','ICAO','SHC','CRED','RACSEL-DDVC','IPS-PILGRIMAGE','DICVP'), 'Invalid domain: ' + domain
+    assert domain.upper() in ('DCC','DDCC','DIVOC','ICAO','SHC','CRED','RACSEL-DDVC','IPS-PILGRIMAGE','DICVP','PH4H'), 'Invalid domain: ' + domain


### PR DESCRIPTION
PH4H = Panamerican Health .... 
This shall succeed the DDVC-Racsel domain

 check how domains may get deprectated in the future

AC

smart trust network gateway accepted PH4H as new supported domain
participant onboarding repository supports new domain
template repository outlines PH4H as supported domain