### PR TITLE
Supported Domains to be kept as per JIRA DDCCGW-723 

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The incoming content needs to be checked for the following rules:
 
 ## Certificate Checks
 
-Most of the checks following the [Certificate Covernance](https://github.com/WorldHealthOrganization/smart-trust/blob/main/input/pagecontent/concepts_certificate_governance.md) which defines the key length and key usage critiera. Additionally there will be more checks in future refering to DCC, IPS-PILGRIMAGE, PH4H and other domains.
+Most of the checks following the [Certificate Covernance](https://github.com/WorldHealthOrganization/smart-trust/blob/main/input/pagecontent/concepts_certificate_governance.md) which defines the key length and key usage critiera. Additionally there will be more checks in future refering to DCC, IPS-PILGRIMAGE,DICVP,PH4H and other domains.
 
 ### Correct PEM
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The incoming content needs to be checked for the following rules:
 
 ## Certificate Checks
 
-Most of the checks following the [Certificate Covernance](https://github.com/WorldHealthOrganization/smart-trust/blob/main/input/pagecontent/concepts_certificate_governance.md) which defines the key length and key usage critiera. Additionally there will be more checks in future refering to ICAO, DIVOC, DDCC and other domains.
+Most of the checks following the [Certificate Covernance](https://github.com/WorldHealthOrganization/smart-trust/blob/main/input/pagecontent/concepts_certificate_governance.md) which defines the key length and key usage critiera. Additionally there will be more checks in future refering to DCC, IPS-PILGRIMAGE, PH4H and other domains.
 
 ### Correct PEM
 

--- a/scripts/tests/groups_domains.py
+++ b/scripts/tests/groups_domains.py
@@ -10,4 +10,4 @@ def test_valid_domain(cert):
 
     domain = cert.pathinfo.get('domain')
     assert domain, 'Certificate at incorrect location'
-    assert domain.upper() in ('DCC','IPS-PILGRIMAGE','PH4H'), 'Invalid domain: ' + domain
+    assert domain.upper() in ('DCC','IPS-PILGRIMAGE','DICVP','PH4H'), 'Invalid domain: ' + domain

--- a/scripts/tests/groups_domains.py
+++ b/scripts/tests/groups_domains.py
@@ -10,4 +10,4 @@ def test_valid_domain(cert):
 
     domain = cert.pathinfo.get('domain')
     assert domain, 'Certificate at incorrect location'
-    assert domain.upper() in ('DCC','DDCC','DIVOC','ICAO','SHC','CRED','RACSEL-DDVC','IPS-PILGRIMAGE','DICVP','PH4H'), 'Invalid domain: ' + domain
+    assert domain.upper() in ('DCC','IPS-PILGRIMAGE','PH4H'), 'Invalid domain: ' + domain


### PR DESCRIPTION
Supported Domains to be kept: DCC, IPS-PILGRIMAGE, PH4H as per JIRA DDCCGW-723 , other domains will be cleaned up.

kept only supported domains
Updated Readme.md